### PR TITLE
Fix image embed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Pour utiliser l'extension, glissez le bloc "LCD Afficher" dans votre cinématiqu
     
 # Exemple
 <br />
+
 ![alt tag](https://github.com/paulcoiffier/mblock_lcd_shield_extension/blob/master/screenshot.png)


### PR DESCRIPTION
Prior to this change the image was not being displayed in README.md. This issue might have been caused by a recent change in GitHub's Markdown interpreter, which now strictly enforces the [GFM spec](https://github.github.com/gfm/). This has caused some Markdown to no longer work.

README.md as it displays without this change:

![clipboard01](https://cloud.githubusercontent.com/assets/8572152/25029074/af5814bc-206e-11e7-809e-2ce6c0f120a1.png)
